### PR TITLE
Use new password client from PyPi.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM satregistry.ehps.ncsu.edu:7001/it/python-image@sha256:a681d9aac60bc0b4ddcf52cc84a3319fb6a9d309acd3cd280122d3f060e18d1d
+FROM satregistry.ehps.ncsu.edu:7001/it/python-image:latest
 
 WORKDIR /app
 
@@ -10,4 +10,4 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "main:app", "--reload", "--host", "0.0.0.0"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This service handles all authentication and authorization needs for SAT applicat
 ## Required Environment Variables
 - `GOOGLE_CLIENT_ID`: This ID is required to decode Google Auth tokens.
 - `JWT_SECRET`: This key is used to encode and decode JWT's sent to clients.
-- `MONGODB_URL`: The connection string to the MongoDB instance.
+- `MONGODB_URL`: The connection string to the MongoDB instance. The password for the database can be hardcoded into the string, or it can be replaced with "password" to be replaced with the password from Passwordstate.
+- `PASSWORD_API_BASE_URL`: The base URL for the Passwordstate API.
+- `PASSWORD_API_KEY`: The API Key used to authenticate with the Passwordstate API.
+- `PASSWORD_API_LIST_ID`: The List ID for Passwordstate.
+- `PASSWORD_TITLE`: The title of the password to use for the MongoDB database.
 
 ## Other Requirements
 A MongoDB database is required for this service to work. The database name should be `Accounts`, and it should contain one collection called `accounts`. A MongoDB instance can be spun up easily with docker:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ google-auth
 requests
 pymongo
 pytest
+password-state-client

--- a/util/db.py
+++ b/util/db.py
@@ -15,11 +15,17 @@ class AuthDB:
     def __setup_database(cls):
         """Gets password from Passwordstate."""
         if cls.account_collection is None:
-            passwordstate = passwords.PasswordstateLookup(os.getenv('API_KEY'))
-            password_data = passwordstate.get_pw(os.getenv('MONGO_PASSWORD_ID'))
+            passwordstate = passwords.PasswordstateLookup(
+                os.getenv('PASSWORD_API_BASE_URL'),
+                os.getenv('PASSWORD_API_KEY'))
+            password_data = passwordstate.get_pw_by_title(
+                os.getenv('PASSWORD_API_LIST_ID'),
+                os.getenv('PASSWORD_TITLE'))
             mongo_connection = os.getenv('MONGODB_URL')
-            client = MongoClient(mongo_connection.replace('password', password_data))
-            cls.account_collection = client['Accounts'].get_collection('accounts')
+            client = MongoClient(mongo_connection.replace(
+                'password', password_data))
+            cls.account_collection = client['Accounts'].get_collection(
+                'accounts')
 
     @classmethod
     def get_account_by_email(cls, email: str) -> dict:
@@ -36,7 +42,9 @@ class AuthDB:
         """Updates an account in the database."""
         cls.__setup_database()
 
-        return cls.account_collection.update_one({'email': account['email']}, {'$set': account})
+        return cls.account_collection.update_one({
+            'email': account['email']},
+            {'$set': account})
 
     @classmethod
     def delete_account(cls, account: dict):


### PR DESCRIPTION
**What Changed**
The auth service now uses the version of the password client from PyPi instead of the base image. Additionally, it uses the new `get_pw_by_title` method instead of by ID.

**How it was Tested**
This change was tested manually and by running the existing tests.