### PR TITLE
Fix logic error with setting write permissions.

### DIFF
--- a/models/Account.py
+++ b/models/Account.py
@@ -25,16 +25,24 @@ class Account:
         """Deletes this instance from the database."""
         return AuthDB.delete_account(self.__dict__)
 
-    def get_authorization(self, service_name):
+    def get_authorization(self, service_name: str):
         """Returns the authorization data given a service name. Does not """
         return self.authorizations[service_name]
 
-    def update_authorization(self, service_name, auth_info):
+    def update_authorization(self, service_name: str, new_authorizations: dict):
         """Updates an authorization record given a service name."""
-        self.authorizations[service_name] = auth_info
+        read_values = new_authorizations.pop('_read', {})
+        write_values = new_authorizations.pop('_write', {})
+
+        self.authorizations[service_name] = self.authorizations.get(
+            service_name, {}) | new_authorizations
+        self.authorizations[service_name]['_read'] = self.authorizations.get(
+            service_name, {}).get('_read', {}) | read_values
+        self.authorizations[service_name]['_write'] = self.authorizations.get(
+            service_name, {}).get('_write', {}) | write_values
         return
 
-    def remove_authorization(self, service_name):
+    def remove_authorization(self, service_name: str):
         """Removes an authorization record given a service name."""
         if service_name in self.authorizations:
             return self.authorizations.pop(service_name)

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -249,7 +249,9 @@ def test_add_update_authorization(monkeypatch):
     assert response.json() == {
         'authorizations': {
             'test-app': {
-                'access': True
+                'access': True,
+                '_read': {},
+                '_write': {}
             }
         }
     }
@@ -282,17 +284,23 @@ def test_subtract_update_authorization(monkeypatch):
 
     token = Token.generate_token(ADMIN_ACCOUNT_FULL_PERMISSION)
     response = client.put('/update-authorization',
-                          headers={'Authorization': f'Bearer {token}'},
-                          json={
-                              'email': 'user@ncsu.edu',
-                              'app_id': 'test-app',
-                              'authorization': {}
-                          })
+                        headers={'Authorization': f'Bearer {token}'},
+                        json={
+                            'email': 'user@ncsu.edu',
+                            'app_id': 'test-app',
+                            'authorization': {
+                                'access': False
+                            }
+                        })
 
     assert response.status_code == 200
     assert response.json() == {
         'authorizations': {
-            'test-app': {}
+            'test-app': {
+                'access': False,
+                '_read': {},
+                '_write': {}
+            }
         }
     }
 
@@ -330,7 +338,9 @@ def test_add_update_authorization_with_some_permission(monkeypatch):
     assert response.json() == {
         'authorizations': {
             'test-app': {
-                'access': True
+                'access': True,
+                '_read': {},
+                '_write': {}
             }
         }
     }
@@ -366,17 +376,23 @@ def test_subtract_update_authorization_with_some_permission(monkeypatch):
 
     token = Token.generate_token(ADMIN_ACCOUNT_SOME_PERMISSION)
     response = client.put('/update-authorization',
-                          headers={'Authorization': f'Bearer {token}'},
-                          json={
-                              'email': 'user@ncsu.edu',
-                              'app_id': 'test-app',
-                              'authorization': {}
-                          })
+                        headers={'Authorization': f'Bearer {token}'},
+                        json={
+                            'email': 'user@ncsu.edu',
+                            'app_id': 'test-app',
+                            'authorization': {
+                                'access': False
+                            }
+                        })
 
     assert response.status_code == 200
     assert response.json() == {
         'authorizations': {
-            'test-app': {}
+            'test-app': {
+                'access': False,
+                '_read': {},
+                '_write': {}
+            }
         }
     }
 


### PR DESCRIPTION
## Changes

If an account has permission to write to a certain role, it is now implied that the role can also be written to the `_read` and `_write` attributes too.

## How was this tested?

Automated testing, testing with Postman, and testing in the Clearance UI.

## Notes to reviewer

This change is made in conjunction with a change to the Clearance UI.