### PR TITLE
183119858 role models

### DIFF
--- a/controllers/authorization.py
+++ b/controllers/authorization.py
@@ -10,16 +10,14 @@ router = APIRouter()
 
 class UpdateAuthorizationRequestBody(BaseModel):
     """Request body model."""
-    authorization: dict
-    app_id: str
     email: str
+    add_roles: list[str] = []
+    remove_roles: list[str] = []
 
 
-@router.get('/authorizations', tags=['Authorization'])
-def get_accounts_with_authorization(response: Response,
-                                    app_id: str,
-                                    db_filter: str,
-                                    value: str,
+@router.get('/role-accounts', tags=['Authorization'])
+def get_accounts_with_role(response: Response,
+                                    role: str,
                                     authorization: str = Header(default=None)):
     """Gets all accounts with specified authorizations.
 
@@ -31,18 +29,15 @@ def get_accounts_with_authorization(response: Response,
     # Get read permissions of the requesting account.
     requesting_account = Token.decode_token(authorization.split(' ')[1])
     requesting_account = Account.find_by_email(requesting_account['email'])
-    read_permissions: dict = requesting_account.authorizations.get(
-                                            app_id, {}).get('_read', {})
+    read_permissions: dict = requesting_account.authorizations.get('_read', [])
 
     # If requesting user has permission, return accounts data.
-    if read_permissions.get(
-                        '_superuser', False) is True or read_permissions.get(
-                        db_filter, False) is True:
-        accounts = Account.find_by_authorization(app_id, db_filter, value)
+    if role in read_permissions:
+        accounts = Account.find_by_role(role)
     else:
         response.status_code = status.HTTP_400_BAD_REQUEST
         return {
-            'error': """This account is not authorized to write to this user's authorization(s)."""
+            'error': 'This account is not authorized to write to this user\'s authorization(s).'
         }
 
     return {
@@ -50,7 +45,7 @@ def get_accounts_with_authorization(response: Response,
     }
 
 
-@router.put('/update-authorization', tags=['Authorization'])
+@router.put('/update-account-roles', tags=['Authorization'])
 def update_authorization(response: Response,
                          body: UpdateAuthorizationRequestBody,
                          authorization: str = Header(default=None)):
@@ -66,102 +61,28 @@ def update_authorization(response: Response,
     # Get write permissions of the requesting account.
     requesting_account = Token.decode_token(authorization.split(' ')[1])
     requesting_account = Account.find_by_email(requesting_account['email'])
-    write_permissions: dict = requesting_account.authorizations.get(
-                                            body.app_id, {}).get('_write', {})
+    write_permissions: dict = requesting_account.authorizations.get('_write', [])
 
     account = Account.find_by_email(body.email)
 
-    # -- Ensure this user has permission to update this authorization. --
+    # Verify that the requesting account has permission to assign this role.
+    can_assign_roles: bool = all(role in write_permissions for role in body.add_roles)
+    can_revoke_roles: bool = all(role in write_permissions for role in body.remove_roles)
 
-    # User can edit permissions if they have superuser privilages.
-    can_write_permissions: bool = write_permissions.get('_superuser', False)
+    if can_assign_roles and can_revoke_roles:
+        for role in body.remove_roles:
+            account.remove_role(role)
+        for role in body.add_roles:
+            account.add_role(role)
 
-    # If they don't have superuser privilages, each key must be checked.
-    if not can_write_permissions:
-
-        # Get list of all keys that should change.
-        existing_authorization_keys = list(
-            account.authorizations.get(body.app_id, {}).keys())
-        future_authorization_keys = list(body.authorization.keys())
-        authorization_key_change_delta = list(
-            set(existing_authorization_keys).difference(
-                set(future_authorization_keys)))
-        changing_keys = future_authorization_keys + authorization_key_change_delta
-        changing_keys = list(filter(lambda k: k != '_read' and k != '_write', changing_keys))
-
-        # Check if user has write access on each key.
-        has_individual_permissions = True
-
-        for key in changing_keys:
-            if not write_permissions.get(key, False):
-                has_individual_permissions = False
-                break
-        for key in body.authorization.get('_read', {}):
-            if not write_permissions.get(key, False):
-                has_individual_permissions = False
-                break
-        for key in body.authorization.get('_write', {}):
-            if not write_permissions.get(key, False):
-                has_individual_permissions = False
-                break
-
-        can_write_permissions = has_individual_permissions
-
-
-    # -- If requesting user has permission, write new permissions to database. --
-    if can_write_permissions:
-        account.update_authorization(body.app_id, body.authorization)
         account.update()
     else:
         response.status_code = status.HTTP_400_BAD_REQUEST
         return {
-            'error': """This account is not authorized to write to this user's authorization(s)."""
+            'error': 'This account is not authorized to write to this user\'s authorization(s).'
         }
 
+    account.__dict__.copy().pop('authorizations')
     return {
-        'authorizations': account.authorizations
-    }
-
-
-@router.delete('/delete-authorization', tags=['Authorization'])
-def remove_authorization(response: Response,
-                         app_id: str,
-                         email: str,
-                         authorization: str = Header(default=None)):
-    """Removes a record of authorization from a user's account.
-
-    Takes a value for app_id, then removes the entire record of
-    authorization for that app in the user's account.
-    """
-
-    # Get write permissions of the requesting account.
-    requesting_account = Token.decode_token(authorization.split(' ')[1])
-    requesting_account = Account.find_by_email(requesting_account['email'])
-    write_permissions: dict = requesting_account.authorizations.get(
-                                            app_id, {}).get('_write', {})
-
-    # If requesting user has permission,
-    # delete app permission(s) from the database.
-    if write_permissions.get('_superuser', False) is True:
-        account = Account.find_by_email(email)
-    else:
-        response.status_code = status.HTTP_400_BAD_REQUEST
-        return {
-            'error': """This account is not authorized to delete this user's authorization(s)."""
-        }
-
-    try:
-        account.remove_authorization(app_id)
-
-    except RuntimeError as _:
-        response.status_code = status.HTTP_400_BAD_REQUEST
-        return {
-            'authorizations': account.authorizations,
-            'message': 'This authorization already does not exsit.'
-        }
-
-    account.update()
-
-    return {
-        'authorizations': account.authorizations
+        'account': account.__dict__
     }

--- a/controllers/authorization.py
+++ b/controllers/authorization.py
@@ -82,7 +82,11 @@ def update_authorization(response: Response,
             'error': 'This account is not authorized to write to this user\'s authorization(s).'
         }
 
-    account.__dict__.copy().pop('authorizations')
+    account_response = account.__dict__.copy()
+
+    if account_response.get('authorizations', False):
+        account_response.pop('authorizations')
+
     return {
-        'account': account.__dict__
+        'account': account_response
     }

--- a/models/Account.py
+++ b/models/Account.py
@@ -60,13 +60,12 @@ class Account:
 
         :param filter: The attribute that should be searched.
         """
-        db_accounts = AuthDB.get_account_by_role(role)
+        db_accounts = AuthDB.get_accounts_by_role(role)
 
         accounts = []
         for account in db_accounts:
             accounts.append(Account(config=account))
 
-        print(accounts)
         return accounts
 
     @staticmethod

--- a/models/Account.py
+++ b/models/Account.py
@@ -7,6 +7,7 @@ class Account:
     """The Account model handles CRUD functions for accounts."""
     email = None
     campus_id = None
+    roles = []
     authorizations = {}
 
     def __init__(self, config):
@@ -14,6 +15,8 @@ class Account:
             self.email = config['email']
         if 'campus_id' in config:
             self.campus_id = config['campus_id']
+        if 'roles' in config:
+            self.roles = list(set(config['roles']))
         if 'authorizations' in config:
             self.authorizations = config['authorizations']
 
@@ -21,40 +24,27 @@ class Account:
         """Updates this instance in the database."""
         return AuthDB.update_account(self.__dict__)
 
+    def add_role(self, role):
+        """Adds a role to this user if it is not already added."""
+        if role not in self.roles:
+            self.roles.append(role)
+
+    def remove_role(self, role):
+        """Removes a role from this user, if they have it."""
+        if role in self.roles:
+            self.roles.remove(role)
+
     def delete(self):
         """Deletes this instance from the database."""
         return AuthDB.delete_account(self.__dict__)
-
-    def get_authorization(self, service_name: str):
-        """Returns the authorization data given a service name. Does not """
-        return self.authorizations[service_name]
-
-    def update_authorization(self, service_name: str, new_authorizations: dict):
-        """Updates an authorization record given a service name."""
-        read_values = new_authorizations.pop('_read', {})
-        write_values = new_authorizations.pop('_write', {})
-
-        self.authorizations[service_name] = self.authorizations.get(
-            service_name, {}) | new_authorizations
-        self.authorizations[service_name]['_read'] = self.authorizations.get(
-            service_name, {}).get('_read', {}) | read_values
-        self.authorizations[service_name]['_write'] = self.authorizations.get(
-            service_name, {}).get('_write', {}) | write_values
-        return
-
-    def remove_authorization(self, service_name: str):
-        """Removes an authorization record given a service name."""
-        if service_name in self.authorizations:
-            return self.authorizations.pop(service_name)
-        else:
-            raise RuntimeError('This service does not exist in this authorization.')
 
     @staticmethod
     def find_by_email(email):
         """
         Finds an account given an email address.
 
-        :param email: The email addres of the account.
+        Parameters:
+            email: The email address of the account.
         """
         db_account = AuthDB.get_account_by_email(email)
         if db_account is None:
@@ -64,21 +54,23 @@ class Account:
             return Account(config=db_account)
 
     @staticmethod
-    def find_by_authorization(app_id, db_filter, value):
+    def find_by_role(role):
         """
         Finds accounts given authorization data.
 
         :param filter: The attribute that should be searched.
         """
-        db_accounts = AuthDB.get_account_by_authorization(f'authorizations.{app_id}.{db_filter}', value)
+        db_accounts = AuthDB.get_account_by_role(role)
+
         accounts = []
         for account in db_accounts:
             accounts.append(Account(config=account))
 
+        print(accounts)
         return accounts
 
     @staticmethod
-    def create_account(email, campus_id, authorizations=None):
+    def create_account(email, campus_id, roles=None):
         """
         Creates a new account in the database.
 
@@ -86,9 +78,9 @@ class Account:
         :param campus_id: The campus ID of the new account.
         :param authorizations: The authorization data of the account.
         """
-        if authorizations is None:
-            authorizations = {}
+        if roles is None:
+            roles = []
         account_data = {'email': email, 'campus_id': campus_id,
-                        'authorizations': authorizations}
+                        'roles': roles}
         AuthDB.create_account(account_data)
         return Account(config=account_data)

--- a/util/db.py
+++ b/util/db.py
@@ -10,11 +10,12 @@ import passwords
 class AuthDB:
     """Helper class for database functions."""
     account_collection = None
+    role_collection = None
 
     @classmethod
     def __setup_database(cls):
         """Gets password from Passwordstate."""
-        if cls.account_collection is None:
+        if cls.account_collection is None or cls.role_collection is None:
             passwordstate = passwords.PasswordstateLookup(
                 os.getenv('PASSWORD_API_BASE_URL'),
                 os.getenv('PASSWORD_API_KEY'))
@@ -24,8 +25,11 @@ class AuthDB:
             mongo_connection = os.getenv('MONGODB_URL')
             client = MongoClient(mongo_connection.replace(
                 'password', password_data))
+
             cls.account_collection = client['Accounts'].get_collection(
                 'accounts')
+            cls.role_collection = client['Accounts'].get_collection(
+                'roles')
 
     @classmethod
     def get_account_by_email(cls, email: str) -> dict:
@@ -34,19 +38,40 @@ class AuthDB:
 
         Parameters:
             email: The email address of the account.
-        
+
         Returns:
             The account data.
         """
         cls.__setup_database()
 
         account_data: dict = cls.account_collection.find_one({'email': email})
+
         if account_data is not None:
+            authorization_data: list[dict] = cls.role_collection.find(
+                {'name': {'$in': account_data.get('roles', [])}})
+
+            authorizations = {}
+            read_roles = []
+            write_roles = []
+            for data in authorization_data:
+                data_read_roles = data.get('authorizations', {}).get('_read', [])
+                data_write_roles = data.get('authorizations', {}).get('_write', [])
+                data['authorizations'].pop('_read')
+                data['authorizations'].pop('_write')
+                data.pop('_id')
+                authorizations.update(data['authorizations'])
+                read_roles = read_roles + data_read_roles
+                write_roles = write_roles + data_write_roles
+
             account_data.pop('_id')
+            authorizations['_read'] = read_roles
+            authorizations['_write'] = write_roles
+            account_data['authorizations'] = authorizations
+
         return account_data
-    
+
     @classmethod
-    def get_account_by_authorization(cls, key: str, value: str) -> list[dict]:
+    def get_account_by_role(cls, value: str) -> list[dict]:
         """
         Finds all accounts from the mongo database that have a given
         authorization.
@@ -54,25 +79,62 @@ class AuthDB:
         Parameters:
             key: The key in the user's authorization data to test.
             value: The value which will be true for all returned accounts.
-        
+
         Returns:
             All accounts with the given authorization.
         """
         cls.__setup_database()
 
-        account_data: list[dict] = cls.account_collection.find({key: value})
-        return account_data
+        account_data: list[dict] = cls.account_collection.aggregate([
+            {
+                '$match': {'roles': value}
+            },
+            {
+                '$lookup': {
+                    'from': 'roles',
+                    'localField': 'roles',
+                    'foreignField': 'name',
+                    'as': 'authorizations'
+                }
+            }
+        ])
+
+        transformed_account_data = []
+        for data in account_data:
+            authorizations = {}
+            read_roles = []
+            write_roles = []
+            for auth in data['authorizations']:
+                data_read_roles = auth.get('authorizations', {}).get('_read', [])
+                data_write_roles = auth.get('authorizations', {}).get('_write', [])
+                auth['authorizations'].pop('_read')
+                auth['authorizations'].pop('_write')
+                authorizations.update(auth.get('authorizations', {}))
+                read_roles = read_roles + data_read_roles
+                write_roles = write_roles + data_write_roles
+
+            data.pop('_id')
+            authorizations['_read'] = read_roles
+            authorizations['_write'] = write_roles
+            data['authorizations'] = authorizations
+            transformed_account_data.append(data)
+
+        return transformed_account_data
 
     @classmethod
     def update_account(cls, account: dict):
         """
         Updates an account in the database.
+
+        Parameters:
+            account: The account data.
         """
         cls.__setup_database()
+
+        account.copy().pop('authorizations')
         return cls.account_collection.update_one({
             'email': account['email']},
             {'$set': account})
-
 
     @classmethod
     def delete_account(cls, account: dict):
@@ -91,7 +153,7 @@ class AuthDB:
         Creates an account in the mongo database.
 
         Parameters
-            account: The account data.
+            account_data: The account data.
         """
         cls.__setup_database()
         return cls.account_collection.insert_one(account_data)

--- a/util/db.py
+++ b/util/db.py
@@ -71,7 +71,7 @@ class AuthDB:
         return account_data
 
     @classmethod
-    def get_account_by_role(cls, value: str) -> list[dict]:
+    def get_accounts_by_role(cls, value: str) -> list[dict]:
         """
         Finds all accounts from the mongo database that have a given
         authorization.
@@ -131,10 +131,13 @@ class AuthDB:
         """
         cls.__setup_database()
 
-        account.copy().pop('authorizations')
+        account_copy = account.copy()
+        if account_copy.get('authorizations', False):
+            account_copy.pop('authorizations')
+
         return cls.account_collection.update_one({
-            'email': account['email']},
-            {'$set': account})
+            'email': account_copy['email']},
+            {'$set': account_copy})
 
     @classmethod
     def delete_account(cls, account: dict):


### PR DESCRIPTION
## Changes

The auth service has fundamentally changed how authorizations work. Authorizations are far more granular, and they're stored in models called Roles. Roles can be assigned to individuals to inherit the authorizations they represent.

## How was this tested?

This was tested through automated testing, in Postman, and in the browser.

## Notes to reviewer

This update should _not_ be merged into main until all services that rely on this service are upgraded to support the new system.