### PR TITLE
remove references to campus_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Documents in the `accounts` collection have three attributes (not including `_id
 | Name | Value | Type | Example |
 | --- | --- | --- | --- |
 | email | The full email address of the user. | String | user@university.edu |
-| campus_id | The campus_id of the account. | String | 000101234 |
 | roles | An array of roles assigned to the individual of the account. | Array[String] | [admin] |
 
 ### Collection: `roles`
@@ -71,7 +70,6 @@ The authorizations dictionary can have any values; they'll appear in the token p
     {
         "_id": ObjectId('asdf'),
         "email": "user@university.edu",
-        "campus_id": "200103374",
         "roles": ["admin"]
     }
 ]

--- a/main.py
+++ b/main.py
@@ -17,11 +17,10 @@ Handle authentication and authorization in your app. Sign in with Google and get
 Right now, only Google Sign In is supported. More ways to sign in can be added in the future. When a token from Google is passed into the appropriate endpoint, a new token is generated with the user's data. That new token is sent back to the client, and it is that token which is used between the services. The Google token is only used once to initially authenticate.
 
 ## Authorization
-The payload of the token contains the user's email address, campus ID, their roles, and their authorizations. Here's what a payload could look like:
+The payload of the token contains the user's email address, their roles, and their authorizations. Here's what a payload could look like:
 ```
 {
     "email": "user@university.edu",
-    "campus_id: "200101234",
     "roles": ["admin"],
     "authorizations: {
         root: true

--- a/models/Account.py
+++ b/models/Account.py
@@ -6,15 +6,12 @@ from util.db import AuthDB
 class Account:
     """The Account model handles CRUD functions for accounts."""
     email = None
-    campus_id = None
     roles = []
     authorizations = {}
 
     def __init__(self, config):
         if 'email' in config:
             self.email = config['email']
-        if 'campus_id' in config:
-            self.campus_id = config['campus_id']
         if 'roles' in config:
             self.roles = list(set(config['roles']))
         if 'authorizations' in config:
@@ -69,17 +66,16 @@ class Account:
         return accounts
 
     @staticmethod
-    def create_account(email, campus_id, roles=None):
+    def create_account(email, roles=None):
         """
         Creates a new account in the database.
 
         :param email: The email address of the account.
-        :param campus_id: The campus ID of the new account.
         :param authorizations: The authorization data of the account.
         """
         if roles is None:
             roles = []
-        account_data = {'email': email, 'campus_id': campus_id,
+        account_data = {'email': email,
                         'roles': roles}
         AuthDB.create_account(account_data)
         return Account(config=account_data)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -9,7 +9,6 @@ client = TestClient(app)
 os.environ["JWT_SECRET"] = "TEST_SECRET"
 
 EMAIL = 'user@university.edu'
-CAMPUS_ID = '200101234'
 EXPIRED_JWT = (
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2Njg3MDU2NzMsImVtYWlsIj"
     "oibG1lbmFAbmNzdS5lZHUiLCJjYW1wdXNfaWQiOiIwMDExMzI4MDgiLCJyb2xlcyI6WyJ0Z"
@@ -31,7 +30,7 @@ def test_decode_google_token(monkeypatch):
         return {'email': EMAIL}
 
     def mock_find_by_email(*args, **kwargs):
-        return Account({'email': EMAIL, 'campus_id': CAMPUS_ID, 'authorizations': {}})
+        return Account({'email': EMAIL, 'authorizations': {}})
 
     monkeypatch.setattr(Token, 'decode_google_token', mock_decode_google_token)
     monkeypatch.setattr(Account, 'find_by_email', mock_find_by_email)
@@ -63,7 +62,7 @@ def test_decode_token():
 
 def test_refresh_token(monkeypatch):
     def mock_find_by_email(*args, **kwargs):
-        return Account({'email': EMAIL, 'campus_id': CAMPUS_ID, 'authorizations': {}})
+        return Account({'email': EMAIL, 'authorizations': {}})
 
     monkeypatch.setattr(Account, 'find_by_email', mock_find_by_email)
 

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -29,13 +29,11 @@ MEMBER_ROLE = {
 
 ADMIN_ACCOUNT = {
     'email': 'admin@university.edu',
-    'campus_id': '00101234',
-    'roles': ['admin']
+    'roles': ['Admin']
 }
 
 MEMBER_ACCOUNT = {
     'email': 'member@university.edu',
-    'campus_id': '00101235',
     'roles': ['member']
 }
 
@@ -63,7 +61,6 @@ def test_get_accounts_with_role(monkeypatch):
     def mock_get_account_by_email(*_, **__):
         return {
             'email': 'admin@university.edu',
-            'campus_id': '00101234',
             'roles': ['admin'],
             'authorizations': {
                 'root': True,
@@ -76,7 +73,6 @@ def test_get_accounts_with_role(monkeypatch):
         return [
             {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -133,7 +129,6 @@ def test_get_account_with_role_unauthorized(monkeypatch):
     def mock_get_account_by_email(*_, **__):
         return {
             'email': 'member@university.edu',
-            'campus_id': '00101235',
             'roles': ['member'],
             'authorizations': {
                 'can_do_x': True,
@@ -147,7 +142,6 @@ def test_get_account_with_role_unauthorized(monkeypatch):
         return [
             {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,
@@ -190,7 +184,6 @@ def test_add_role(monkeypatch):
         if email == 'member@university.edu':
             return {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -202,7 +195,6 @@ def test_add_role(monkeypatch):
         else:
             return {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,
@@ -271,7 +263,6 @@ def test_add_role_unauthorized(monkeypatch):
         if email == 'member@university.edu':
             return {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -283,7 +274,6 @@ def test_add_role_unauthorized(monkeypatch):
         else:
             return {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,
@@ -330,7 +320,6 @@ def test_remove_role(monkeypatch):
         if email == 'member@university.edu':
             return {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -342,7 +331,6 @@ def test_remove_role(monkeypatch):
         else:
             return {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,
@@ -374,7 +362,6 @@ def test_remove_role(monkeypatch):
 
     expected_account_state = {
         'email': 'member@university.edu',
-        'campus_id': '00101235',
         'roles': []
     }
 
@@ -392,7 +379,6 @@ def test_remove_role_unauthorized(monkeypatch):
         if email == 'member@university.edu':
             return {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -404,7 +390,6 @@ def test_remove_role_unauthorized(monkeypatch):
         else:
             return {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,
@@ -448,7 +433,6 @@ def test_add_and_remove_roles(monkeypatch):
         if email == 'member@university.edu':
             return {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -460,7 +444,6 @@ def test_add_and_remove_roles(monkeypatch):
         else:
             return {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,
@@ -493,7 +476,6 @@ def test_add_and_remove_roles(monkeypatch):
 
     expected_account_state = {
         'email': 'member@university.edu',
-        'campus_id': '00101235',
         'roles': ['admin']
     }
 
@@ -511,7 +493,6 @@ def test_add_and_remove_roles_unauthorized(monkeypatch):
         if email == 'member@university.edu':
             return {
                 'email': 'member@university.edu',
-                'campus_id': '00101235',
                 'roles': ['member'],
                 'authorizations': {
                     'can_do_x': True,
@@ -523,7 +504,6 @@ def test_add_and_remove_roles_unauthorized(monkeypatch):
         else:
             return {
                 'email': 'admin@university.edu',
-                'campus_id': '00101234',
                 'roles': ['admin'],
                 'authorizations': {
                     'root': True,


### PR DESCRIPTION
## Changes

The auth service doesn’t populate campus IDs for new users, and shouldn’t store them. Other services that use the auth service can find the user’s campus ID if they need to, or just use the email field

Edit the auth service to only create email and roles properties for new documents in the Accounts.accounts collection

## How was this tested?

Manually, running pytest

## How were these changes documented?

Updated documentation to reflect the new structure
